### PR TITLE
Used third-party library "Glide" to load images in RecyclerView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,7 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation 'com.github.BlacKCaT27:CurrencyEditText:2.0.2'
+
+    implementation 'com.github.bumptech.glide:glide:4.14.2'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.14.2'
 }

--- a/app/src/main/java/com/example/capsule/ui/outfits/HorizontalRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/example/capsule/ui/outfits/HorizontalRecyclerViewAdapter.kt
@@ -5,7 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.example.capsule.R
 import com.example.capsule.model.Clothing
 
@@ -17,7 +19,8 @@ import com.example.capsule.model.Clothing
  * @property clothing List of clothing entries
  * @property clothingSelectedListener
  */
-class HorizontalRecyclerViewAdapter(private val clothingCategory: String,
+class HorizontalRecyclerViewAdapter(private val fragment: Fragment,
+                                    private val clothingCategory: String,
                                     private val clothing : List<Clothing>,
                                     private val clothingSelectedListener : OnClothingSelectedListener) : RecyclerView.Adapter<HorizontalRecyclerViewAdapter.ViewHolder>(){
     // set default position to be the first position or in other words, no clothes selected
@@ -54,8 +57,7 @@ class HorizontalRecyclerViewAdapter(private val clothingCategory: String,
         }
         else {
             val uri : Uri = Uri.parse(clothing[position-1].img_uri)
-            holder.imageView.setImageURI(uri)
-            //holder.imageView.setImageResource(R.drawable.stars)
+            Glide.with(fragment).load(uri).into(holder.imageView)
             clothingId = clothing[position-1].id
         }
 

--- a/app/src/main/java/com/example/capsule/ui/outfits/OutfitsFragment.kt
+++ b/app/src/main/java/com/example/capsule/ui/outfits/OutfitsFragment.kt
@@ -54,7 +54,7 @@ class OutfitsFragment : Fragment(), HorizontalRecyclerViewAdapter.OnClothingSele
             textView.text = clothingCategoryStrList[p0]
 
             recyclerView.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
-            recyclerView.adapter = HorizontalRecyclerViewAdapter(clothingCategoryStrList[p0], clothing[p0], this@OutfitsFragment)
+            recyclerView.adapter = HorizontalRecyclerViewAdapter(this@OutfitsFragment, clothingCategoryStrList[p0], clothing[p0], this@OutfitsFragment)
 
             return v
         }


### PR DESCRIPTION
Using a third party library to load images for more efficient and faster load based on this [stack overflow post](https://stackoverflow.com/questions/44098759/android-imageview-in-listview-how-to-reduce-the-lag)

https://github.com/bumptech/glide

Previously:
`holder.imageView.setImageURI(uri)`

Current (based on the example):
`Glide.with(fragment).load(uri).into(holder.imageView)`

The change above provides a significant faster load time and the library should be considered for our other features in our app which requires images to be loaded into ImageView
