### PR TITLE
Fix item frequency query to include items never worn

### DIFF
--- a/app/src/main/java/com/example/capsule/database/ClothingHistoryDatabaseDao.kt
+++ b/app/src/main/java/com/example/capsule/database/ClothingHistoryDatabaseDao.kt
@@ -24,9 +24,9 @@ interface ClothingHistoryDatabaseDao {
     @Query("DELETE from clothing_history_table")
     fun deleteAllClothingHistory()
 
-    @Query("SELECT CH.clothing_id, C.name, C.img_uri, count(*) as frequency " +
-            "FROM clothing_history_table as CH " +
-            "JOIN clothing_table as C ON CH.clothing_id = C.id " +
+    @Query("SELECT CH.clothing_id, C.name, C.img_uri, count(CH.clothing_id) as frequency " +
+            "FROM clothing_table C " +
+            "LEFT OUTER JOIN clothing_history_table CH ON C.id = CH.clothing_id " +
             "WHERE C.category=:category " +
             "GROUP BY CH.clothing_id " +
             "ORDER BY frequency DESC")


### PR DESCRIPTION
- Frequency stats now include items never worn
<img width="268" alt="Screen Shot 2022-12-04 at 12 52 42 AM" src="https://user-images.githubusercontent.com/54298030/205482134-489f822b-9c8d-4633-919f-40ff1c750627.png">

- previously the query used INNER JOIN so only items worn (existing in clothing_history_table) would show up, but we want to display items they never wear as well
