### PR TITLE
Bugfix/manual logging

### DIFF
--- a/app/src/main/java/com/example/capsule/ui/outfits/OutfitsViewModel.kt
+++ b/app/src/main/java/com/example/capsule/ui/outfits/OutfitsViewModel.kt
@@ -19,7 +19,7 @@ class OutfitsViewModel(private val repository: Repository) : ViewModel() {
 
     fun insertOutfit(clothingHistory: List<ClothingHistory>) {
         for (ch in clothingHistory) {
-            if (ch.id != -1L) {
+            if (ch.clothingId != -1L) {
                 repository.insertClothingHistory(ch)
             }
         }


### PR DESCRIPTION
Simple bugfix of manually logging outfits

Manually outfit would log invalid ClothingHistory entries with invalid clothing_id due to the viewmodel checking the wrong field.