### PR TITLE
Additional UI styling for graphs and tips

### DIFF
--- a/app/src/main/java/com/example/capsule/ui/stats/FrequencyListAdapter.kt
+++ b/app/src/main/java/com/example/capsule/ui/stats/FrequencyListAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.example.capsule.R
 
@@ -42,6 +43,9 @@ class FrequencyListAdapter (
         rankTextView.text = (position+1).toString()
         nameTextView.text = item.name
         freqTextView.text = "${item.frequency} ×"
+        if (item.frequency == 0) {
+            freqTextView.setTextColor(ContextCompat.getColor(context,R.color.red))
+        }
         itemImgView.setImageURI(item.img_uri.toUri())
 
         return view

--- a/app/src/main/java/com/example/capsule/ui/stats/MaterialStatsFragment.kt
+++ b/app/src/main/java/com/example/capsule/ui/stats/MaterialStatsFragment.kt
@@ -28,6 +28,8 @@ class MaterialStatsFragment: Fragment() {
     private lateinit var factory: StatsViewModelFactory
 
     private lateinit var chart: PieChart
+    private lateinit var allMaterials: ArrayList<String>
+    private lateinit var allColours: ArrayList<Int>
     private lateinit var entries: ArrayList<PieEntry>
     private lateinit var colours: ArrayList<Int>
     private lateinit var pieDataSet: PieDataSet
@@ -54,6 +56,8 @@ class MaterialStatsFragment: Fragment() {
         emptyStateHeader = view.findViewById(R.id.material_stats_empty_state)
         emptyStateDescription = view.findViewById(R.id.material_stats_empty_description)
 
+        allColours = resources.getIntArray(R.array.material_graph_colours).toList() as ArrayList<Int>
+        allMaterials = resources.getStringArray(R.array.material_items).toList() as ArrayList<String>
         entries = ArrayList()
         materialFrequencyList = ArrayList()
         chart = view.findViewById(R.id.material_pie_chart)
@@ -97,11 +101,19 @@ class MaterialStatsFragment: Fragment() {
             emptyStateDescription.visibility = View.GONE
             chart.visibility = View.VISIBLE
 
-            colours =
-                resources.getIntArray(R.array.material_graph_colours).toList() as ArrayList<Int>
+            colours = ArrayList()
             entries = ArrayList()
             for (material in materialFrequencyList) {
-                entries.add(PieEntry(material.frequency.toFloat(), material.material))
+
+                var materialIndex = allMaterials.indexOf(material.material)
+                var materialColor = allColours[materialIndex]
+                if (materialIndex <= 4) {
+                    entries.add(0,PieEntry(material.frequency.toFloat(), material.material))
+                    colours.add(0,materialColor)
+                } else {
+                    entries.add(PieEntry(material.frequency.toFloat(), material.material))
+                    colours.add(materialColor)
+                }
             }
             pieDataSet = PieDataSet(entries, "Type")
             pieDataSet.valueTextSize = 12f

--- a/app/src/main/java/com/example/capsule/ui/stats/PurchaseLocationStatsFragment.kt
+++ b/app/src/main/java/com/example/capsule/ui/stats/PurchaseLocationStatsFragment.kt
@@ -30,6 +30,8 @@ class PurchaseLocationStatsFragment: Fragment() {
     private lateinit var purchaseLocationFrequencyList: List<PurchaseLocationFrequency>
 
     private lateinit var chart: PieChart
+    private lateinit var allLocations: ArrayList<String>
+    private lateinit var allColours: ArrayList<Int>
     private lateinit var entries: ArrayList<PieEntry>
     private lateinit var colours: ArrayList<Int>
     private lateinit var pieDataSet: PieDataSet
@@ -55,6 +57,8 @@ class PurchaseLocationStatsFragment: Fragment() {
         emptyStateHeader = view.findViewById(R.id.purchase_loc_empty_state_header)
         emptyStateDescription = view.findViewById(R.id.purchase_loc_empty_state_description)
 
+        allColours = resources.getIntArray(R.array.purchase_loc_graph_colours).toList() as ArrayList<Int>
+        allLocations = resources.getStringArray(R.array.purchase_items).toList() as ArrayList<String>
         entries = ArrayList()
         purchaseLocationFrequencyList = ArrayList()
 
@@ -86,10 +90,12 @@ class PurchaseLocationStatsFragment: Fragment() {
             emptyStateDescription.visibility = View.GONE
             chart.visibility = View.VISIBLE
 
-            colours = resources.getIntArray(R.array.purchase_loc_graph_colours).toList() as ArrayList<Int>
+            colours = ArrayList()
             entries = ArrayList()
             for (location in purchaseLocationFrequencyList) {
                 entries.add(PieEntry(location.frequency.toFloat(), location.purchase_location))
+                var locationColour = allColours[allLocations.indexOf(location.purchase_location)]
+                colours.add(locationColour)
             }
 
             pieDataSet = PieDataSet(entries, "Type")

--- a/app/src/main/java/com/example/capsule/ui/tips/TipsExpandableListViewAdapter.kt
+++ b/app/src/main/java/com/example/capsule/ui/tips/TipsExpandableListViewAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseExpandableListAdapter
-import android.widget.ImageView
 import android.widget.TextView
 import com.example.capsule.R
 
@@ -38,7 +37,7 @@ class TipsExpandableListViewAdapter(private val context : Context, private val t
     }
 
     override fun getGroupView(position: Int, isExpanded: Boolean, convertView: View?, parent: ViewGroup?): View {
-        val v = View.inflate(context, R.layout.group_item, null)
+        val v = View.inflate(context, R.layout.tips_header_item, null)
         val textView : TextView = v.findViewById(R.id.groupItemTextView)
         textView.text = titleList[position]
 
@@ -46,7 +45,7 @@ class TipsExpandableListViewAdapter(private val context : Context, private val t
     }
 
     override fun getChildView(p0: Int, p1: Int, p2: Boolean, p3: View?, p4: ViewGroup?): View {
-        val v = View.inflate(context, R.layout.child_item, null)
+        val v = View.inflate(context, R.layout.tips_child_item, null)
         val textView : TextView = v.findViewById(R.id.childItemTextView)
         textView.text = tipList[p0]
         return textView

--- a/app/src/main/res/layout/fragment_frequency_stats.xml
+++ b/app/src/main/res/layout/fragment_frequency_stats.xml
@@ -21,6 +21,7 @@
         android:layout_marginTop="10dp"
         android:layout_marginBottom="5dp"/>
     <ListView
+        android:layout_marginBottom="50dp"
         android:id="@+id/freq_listview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/fragment_tips.xml
+++ b/app/src/main/res/layout/fragment_tips.xml
@@ -17,6 +17,8 @@
         android:layout_height="wrap_content"
         android:text="@string/title_tips_fragment"
         android:textSize="24sp"
+        android:textColor="@color/fifth"
+        android:textStyle="bold"
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
         android:textAlignment="center" />

--- a/app/src/main/res/layout/tips_child_item.xml
+++ b/app/src/main/res/layout/tips_child_item.xml
@@ -11,6 +11,8 @@
         android:paddingLeft="50dp"
         android:paddingRight="50dp"
         android:textSize="18dp"
+        android:textColor="@color/fourth"
+        android:lineSpacingExtra="5dp"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tips_header_item.xml
+++ b/app/src/main/res/layout/tips_header_item.xml
@@ -10,6 +10,7 @@
         android:id="@+id/groupItemTextView"
         android:textSize="18dp"
         android:textStyle="bold"
+        android:textColor="@color/fifth"
         android:padding="20dp"
         android:paddingLeft="30dp"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -8,12 +8,14 @@
     </string-array>
     <string-array name="material_items">
         <item>Cotton</item>
+        <item>Tencel</item>
         <item>Leather</item>
-        <item>Polyester</item>
+        <item>Linen</item>
         <item>Wool</item>
+        <item>Rubber</item>
         <item>Nylon</item>
         <item>Acrylic</item>
-        <item>Rubber</item>
+        <item>Polyester</item>
     </string-array>
     <string-array name="season_items">
         <item>Spring</item>
@@ -22,9 +24,9 @@
         <item>Winter</item>
     </string-array>
     <string-array name="purchase_items">
-        <item>Brand new</item>
         <item>Thrifted</item>
         <item>Second-hand online</item>
+        <item>Brand new</item>
     </string-array>
     <string-array name="tips_headings">
         <item>What is fast fashion?</item>
@@ -122,17 +124,22 @@
             and can also be dangerous to wear. [Source: FutureLearn]\n
         </item>
         <item>
-            Thrift stores, second-hand platforms, sustainable brands.
+            You should try to shop second-hand first! Try thrifting or looking on
+            second-hand platforms such as Depop or Poshmark. Otherwise,
+            you should shop from sustainable brands that care about the environment,
+            pay their workers fairly, and are transparent across their entire supply chain.
         </item>
     </string-array>
     <integer-array name="material_graph_colours">
-        <item>@color/third</item>
+        <item>@color/graph_0_blue</item>
         <item>@color/graph_1_teal</item>
         <item>@color/graph_2_light_teal</item>
         <item>@color/graph_3_green</item>
         <item>@color/graph_4_lime</item>
         <item>@color/graph_5_ochre</item>
         <item>@color/graph_6_orange</item>
+        <item>@color/graph_7_salmon</item>
+        <item>@color/graph_8_red</item>
     </integer-array>
     <integer-array name="purchase_loc_graph_colours">
         <item>@color/second</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,10 +12,13 @@
     <color name="grey">#C1C1C1</color>
     <color name="red">#E47474</color>
 
-    <color name="graph_1_teal">#418f83</color>
-    <color name="graph_2_light_teal">#459a73</color>
-    <color name="graph_3_green">#60a159</color>
-    <color name="graph_4_lime">#88a538</color>
-    <color name="graph_5_ochre">#b7a412</color>
-    <color name="graph_6_orange">#ec9a00</color>
+    <color name="graph_0_blue">#8BB59D</color>
+    <color name="graph_1_teal">#7BAB96</color>
+    <color name="graph_2_light_teal">#6BA18E</color>
+    <color name="graph_3_green">#5B9687</color>
+    <color name="graph_4_lime">#4B8C7F</color>
+    <color name="graph_5_ochre">#E4A874</color>
+    <color name="graph_6_orange">#E19771</color>
+    <color name="graph_7_salmon">#DD866D</color>
+    <color name="graph_8_red">#DA756A</color>
 </resources>


### PR DESCRIPTION
- Updated colours for pie charts
<img width="209" alt="Screen Shot 2022-12-06 at 2 12 52 AM" src="https://user-images.githubusercontent.com/54298030/205883399-49fad8cf-d261-49be-98d4-ae6bb5da2d00.png">

- If item has never been logged as worn, display red zero
<img width="208" alt="Screen Shot 2022-12-06 at 2 12 37 AM" src="https://user-images.githubusercontent.com/54298030/205883471-3c4b46e8-a653-43a0-9aed-18d04558d780.png">

- Styled tips page to change icon and bold headers
<img width="210" alt="Screen Shot 2022-12-06 at 2 12 25 AM" src="https://user-images.githubusercontent.com/54298030/205883559-7aa2e847-912d-4dc2-a8f2-025dfa1095ec.png">

- Updated some weather icons which were blurry due to smaller image size
